### PR TITLE
Use `String.raw` instead of custom code

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,7 @@ function walker(node) {
 
 const compilerTemplate = document.createElement('template')
 export function h(strings, ...args) {
-  let result = ''
-  for(let i = 0; i < args.length; i++) result += strings[i] + args[i]
-  result += strings[strings.length - 1]
-
-  const template = result
+  const template = String.raw(strings, ...args)
     .replace(/>\n+/g, '>')
     .replace(/\s+</g, '<')
     .replace(/>\s+/g, '>')


### PR DESCRIPTION
the code at the top of the `h` function is doing the same thing as `String.raw` does since you're planning on running in environments supporting string template literals, and String.raw should be available in those contexts, I think you can save yourself some code by just calling out to the static method.