### PR TITLE
FIX: Bug with simple templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function collector(node) {
 
 const TREE_WALKER = document.createTreeWalker(document, NodeFilter.SHOW_ALL, null, false)
 TREE_WALKER.roll = function(n) {
-  let tmp
+  let tmp = this.currentNode
   while(--n) tmp = this.nextNode()
   return tmp
 }

--- a/index.js
+++ b/index.js
@@ -22,10 +22,9 @@ function collector(node) {
 }
 
 const TREE_WALKER = document.createTreeWalker(document, NodeFilter.SHOW_ALL, null, false)
-TREE_WALKER.roll = function(n) {
-  let tmp = this.currentNode
-  while(--n) tmp = this.nextNode()
-  return tmp
+TREE_WALKER.roll = function(n) { 
+  while(--n) this.nextNode()
+  return this.currentNode
 }
 
 class Ref {


### PR DESCRIPTION
This does not work without the change above:

```js
const greeting = h`<h1 #message>Hello</h1>`
const {message} = greeting.collect(greeting)
// message is undefined here but should be an H1 element
message.__click = () => alert('yo')
```

Basically because `TREE_WALKER.roll(1)` should return the current position.