### PR TITLE
Adding TypeScript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+declare class Ref {
+    idx: number;
+    ref: string | number;
+    constructor(idx: number, ref: string | number);
+}
+interface RefObj {
+    [key: string]: any;
+}
+interface hElement extends HTMLElement {
+    _refPaths?: Ref[];
+    collect(node: Node): RefObj;
+}
+export function compile(node: Node): void;
+export default function h(strings: TemplateStringsArray, ...args: any[]): hElement;

--- a/keyed.d.ts
+++ b/keyed.d.ts
@@ -1,0 +1,9 @@
+export default function keyed(
+    key: string,
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/reconcile.d.ts
+++ b/reconcile.d.ts
@@ -1,0 +1,8 @@
+export default function reconcile(
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/reuseNodes.d.ts
+++ b/reuseNodes.d.ts
@@ -1,0 +1,8 @@
+export default function reuseNodes(
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/styles.d.ts
+++ b/styles.d.ts
@@ -1,0 +1,2 @@
+export default function styles(stylesObj: object): object;
+export function keyframes(framesObj: object): object;

--- a/syntheticEvents.d.ts
+++ b/syntheticEvents.d.ts
@@ -1,0 +1,1 @@
+export default function setupSyntheticEvent(name: string): void;


### PR DESCRIPTION
(RE: issue #19)

These definitions have been tested against writing a fancy TodoMVC implementation.

There is a slight awkwardness in the sense that `collect()` returns a `RefObj` of interface `[key: string]: any`. The closest class is `HTMLElement`, however in practice code will often be using superclassed elements such as `HTMLDivElement`. 

So instead of:
```javascript
const view = h`
<div class="application">
    <h1 class="display-number">#number</h1>
    <div class="panel-buttons">
        <button class="button" #down>-</button>
        <button class="button" #up>+</button>
    </div>
</div>
`;

const {number, down, up} = view.collect(view);
```
You will need to coerce the `any` type to the proper element in order to restore type checking: 
```javascript
const view = h`
<div class="application">
    <h1 class="display-number">#number</h1>
    <div class="panel-buttons">
        <button class="button" #down>-</button>
        <button class="button" #up>+</button>
    </div>
</div>
`;

const refs = view.collect(view);
const number = <HTMLHeadingElement> refs.number;
const down = <HTMLButtonElement> refs.down;
const up = <HTMLButtonElement> refs.up;
```
