### PR TITLE
Make 'noOp' optional for reconciliation helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ reconcile(
     newValues,
     // Create callback
     item => document.createTextNode(item),
-    // Update callback
+    // Optional, update callback
     (node, item) => node.nodeValue = item + ' !!!',
     // Optional, node that comes before rendered list
     beforeNode,
@@ -180,7 +180,7 @@ keyed(
     newValues,
     // Create callback
     item => document.createTextNode(item),
-    // Update callback
+    // Optional, update callback
     (node, item) => node.nodeValue = item + ' !!!',
     // Optional, node that comes before rendered list
     beforeNode,
@@ -203,7 +203,7 @@ reuseNodes(
     newValues,
     // Create callback
     item => document.createTextNode(item),
-    // Update callback
+    // Optional, update callback
     (node, item) => node.nodeValue = item + ' !!!',
     // Optional, node that comes before rendered list
     beforeNode,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,14 @@
+declare class Ref {
+    idx: number;
+    ref: string | number;
+    constructor(idx: number, ref: string | number);
+}
+interface RefObj {
+    [key: string]: any;
+}
+interface hElement extends HTMLElement {
+    _refPaths?: Ref[];
+    collect(node: Node): RefObj;
+}
+export function compile(node: Node): void;
+export default function h(strings: TemplateStringsArray, ...args: any[]): hElement;

--- a/keyed.d.ts
+++ b/keyed.d.ts
@@ -1,0 +1,9 @@
+export default function keyed(
+    key: string,
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/keyed.d.ts
+++ b/keyed.d.ts
@@ -4,6 +4,6 @@ export default function keyed(
     renderedValues: any[],
     data: any[],
     createFn: Function,
-    noOp: Function,
+    noOp?: Function,
     beforeNode?: Node,
     afterNode?: Node): void;

--- a/keyed.js
+++ b/keyed.js
@@ -54,7 +54,7 @@ export function keyed(key, parent, renderedValues, data, createFn, noOp, beforeN
         // Skip prefix
         a = renderedValues[prevStart], b = data[newStart]
         while(a[key] === b[key]) {
-            noOp(prevStartNode, b)
+            if (noOp) noOp(prevStartNode, b)
             prevStart++
             newStart++
             newStartNode = prevStartNode = prevStartNode.nextSibling
@@ -66,7 +66,7 @@ export function keyed(key, parent, renderedValues, data, createFn, noOp, beforeN
         // Skip suffix
         a = renderedValues[prevEnd], b = data[newEnd]
         while(a[key] === b[key]) {
-            noOp(prevEndNode, b)
+            if (noOp) noOp(prevEndNode, b)
             prevEnd--
             newEnd--
             afterNode = prevEndNode
@@ -80,7 +80,7 @@ export function keyed(key, parent, renderedValues, data, createFn, noOp, beforeN
         a = renderedValues[prevEnd], b = data[newStart]
         while(a[key] === b[key]) {
             loop = true
-            noOp(prevEndNode, b)
+            if (noOp) noOp(prevEndNode, b)
             _node = prevEndNode.previousSibling
             parent.insertBefore(prevEndNode, newStartNode)
             prevEndNode = _node
@@ -95,7 +95,7 @@ export function keyed(key, parent, renderedValues, data, createFn, noOp, beforeN
         a = renderedValues[prevStart], b = data[newEnd]
         while(a[key] === b[key]) {
             loop = true
-            noOp(prevStartNode, b)
+            if (noOp) noOp(prevStartNode, b)
             _node = prevStartNode.nextSibling
             parent.insertBefore(prevStartNode, afterNode)
             prevStart++
@@ -203,14 +203,14 @@ export function keyed(key, parent, renderedValues, data, createFn, noOp, beforeN
     for(let i = newEnd; i >= newStart; i--) {
         if(longestSeq[lisIdx] === i) {
             afterNode = nodes[P[longestSeq[lisIdx]]]
-            noOp(afterNode, data[i])
+            if (noOp) noOp(afterNode, data[i])
             lisIdx--
         } else {
             if (P[i] === -1) {
                 tmpD = createFn(data[i])
             } else {
                 tmpD = nodes[P[i]]
-                noOp(tmpD, data[i])
+                if (noOp) noOp(tmpD, data[i])
             }
             parent.insertBefore(tmpD, afterNode)
             afterNode = tmpD

--- a/reconcile.d.ts
+++ b/reconcile.d.ts
@@ -3,6 +3,6 @@ export default function reconcile(
     renderedValues: any[],
     data: any[],
     createFn: Function,
-    noOp: Function,
+    noOp?: Function,
     beforeNode?: Node,
     afterNode?: Node): void;

--- a/reconcile.d.ts
+++ b/reconcile.d.ts
@@ -1,0 +1,8 @@
+export default function reconcile(
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/reconcile.js
+++ b/reconcile.js
@@ -54,7 +54,7 @@ export function reconcile(parent, renderedValues, data, createFn, noOp, beforeNo
         // Skip prefix
         a = renderedValues[prevStart], b = data[newStart]
         while(a === b) {
-            noOp(prevStartNode, b)
+            if (noOp) noOp(prevStartNode, b)
             prevStart++
             newStart++
             newStartNode = prevStartNode = prevStartNode.nextSibling
@@ -66,7 +66,7 @@ export function reconcile(parent, renderedValues, data, createFn, noOp, beforeNo
         // Skip suffix
         a = renderedValues[prevEnd], b = data[newEnd]
         while(a === b) {
-            noOp(prevEndNode, b)
+            if (noOp) noOp(prevEndNode, b)
             prevEnd--
             newEnd--
             afterNode = prevEndNode
@@ -80,7 +80,7 @@ export function reconcile(parent, renderedValues, data, createFn, noOp, beforeNo
         a = renderedValues[prevEnd], b = data[newStart]
         while(a === b) {
             loop = true
-            noOp(prevEndNode, b)
+            if (noOp) noOp(prevEndNode, b)
             _node = prevEndNode.previousSibling
             parent.insertBefore(prevEndNode, newStartNode)
             prevEndNode = _node
@@ -95,7 +95,7 @@ export function reconcile(parent, renderedValues, data, createFn, noOp, beforeNo
         a = renderedValues[prevStart], b = data[newEnd]
         while(a === b) {
             loop = true
-            noOp(prevStartNode, b)
+            if (noOp) noOp(prevStartNode, b)
             _node = prevStartNode.nextSibling
             parent.insertBefore(prevStartNode, afterNode)
             prevStart++
@@ -203,14 +203,14 @@ export function reconcile(parent, renderedValues, data, createFn, noOp, beforeNo
     for(let i = newEnd; i >= newStart; i--) {
         if(longestSeq[lisIdx] === i) {
             afterNode = nodes[P[longestSeq[lisIdx]]]
-            noOp(afterNode, data[i])
+            if (noOp) noOp(afterNode, data[i])
             lisIdx--
         } else {
             if (P[i] === -1) {
                 tmpD = createFn(data[i])
             } else {
                 tmpD = nodes[P[i]]
-                noOp(tmpD, data[i])
+                if (noOp) noOp(tmpD, data[i])
             }
             parent.insertBefore(tmpD, afterNode)
             afterNode = tmpD

--- a/reuseNodes.d.ts
+++ b/reuseNodes.d.ts
@@ -3,6 +3,6 @@ export default function reuseNodes(
     renderedValues: any[],
     data: any[],
     createFn: Function,
-    noOp: Function,
+    noOp?: Function,
     beforeNode?: Node,
     afterNode?: Node): void;

--- a/reuseNodes.d.ts
+++ b/reuseNodes.d.ts
@@ -1,0 +1,8 @@
+export default function reuseNodes(
+    parent: HTMLElement,
+    renderedValues: any[],
+    data: any[],
+    createFn: Function,
+    noOp: Function,
+    beforeNode?: Node,
+    afterNode?: Node): void;

--- a/reuseNodes.js
+++ b/reuseNodes.js
@@ -13,7 +13,7 @@ export function reuseNodes(parent, renderedValues, data, createFn, noOp, beforeN
                 node = tmp
             }
         } else {
-            parent.textContent = ""    
+            parent.textContent = ""
         }
         return
     }
@@ -36,7 +36,7 @@ export function reuseNodes(parent, renderedValues, data, createFn, noOp, beforeN
     for(let i = 0, item, head = _head, mode = _mode; i < data.length; i++) {
         item = data[i]
         if (head) {
-            noOp(head, item)
+            if (noOp) noOp(head, item)
         } else {
             head = createFn(item)
             mode ? parent.insertBefore(head, afterNode) : parent.appendChild(head)

--- a/styles.d.ts
+++ b/styles.d.ts
@@ -1,0 +1,2 @@
+export default function styles(stylesObj: object): object;
+export function keyframes(framesObj: object): object;

--- a/syntheticEvents.d.ts
+++ b/syntheticEvents.d.ts
@@ -1,0 +1,1 @@
+export default function setupSyntheticEvent(name: string): void;


### PR DESCRIPTION
I've been using stage0 along with [S.js](https://github.com/adamhaile/S) and [S-array](https://github.com/adamhaile/S-array) for managing updates, which so far has been great.

There's one small gotcha when you're reconciling an array, at the moment you have to stuff an actual no-op like `_ => _` into the `noOp` slot on those functions if you're not going to run any update functions on those array elements.

I've included the TypeScript definition updates for pull-request #24 if you're accepting that one as well.

Updated: Added a README update to the main patch.